### PR TITLE
Standing up on tables doesn't make people clip into walls.

### DIFF
--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -11,8 +11,10 @@ using Content.Shared.Interaction;
 using Content.Shared.Movement.Events;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
+using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Verbs;
+using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics;
@@ -60,6 +62,7 @@ public sealed partial class ClimbSystem : VirtualController
         SubscribeLocalEvent<ClimbingComponent, UpdateCanMoveEvent>(OnMoveAttempt);
         SubscribeLocalEvent<ClimbingComponent, EntParentChangedMessage>(OnParentChange);
         SubscribeLocalEvent<ClimbingComponent, ClimbDoAfterEvent>(OnDoAfter);
+        //SubscribeLocalEvent<ClimbableComponent, StartCollideEvent>(OnStartCollide);
         SubscribeLocalEvent<ClimbingComponent, EndCollideEvent>(OnClimbEndCollide);
         SubscribeLocalEvent<ClimbingComponent, BuckledEvent>(OnBuckled);
         SubscribeLocalEvent<ClimbingComponent, EntGotInsertedIntoContainerMessage>(OnStored);
@@ -294,7 +297,7 @@ public sealed partial class ClimbSystem : VirtualController
         var localDirection = (-parentRot).RotateVec(worldDirection);
 
         // On top of it already so just do it in place.
-        if (localDirection.LengthSquared() < 0.01f)
+        if (localDirection.LengthSquared() < 0.25f)
         {
             climbing.NextTransition = null;
         }

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -297,7 +297,7 @@ public sealed partial class ClimbSystem : VirtualController
         var localDirection = (-parentRot).RotateVec(worldDirection);
 
         // On top of it already so just do it in place.
-        if (localDirection.LengthSquared() < 0.25f)
+        if (localDirection.LengthSquared() < 0.15f)
         {
             climbing.NextTransition = null;
         }

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Climbing.Components;
+using Content.Shared.Climbing.Systems;
 using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
@@ -13,6 +15,7 @@ public sealed class StandingStateSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly ClimbSystem _climbing = default!;
 
     // If StandingCollisionLayer value is ever changed to more than one layer, the logic needs to be edited.
     private const int StandingCollisionLayer = (int) CollisionGroup.MidImpassable;
@@ -153,10 +156,25 @@ public sealed class StandingStateSystem : EntitySystem
             foreach (var key in standingState.ChangedFixtures)
             {
                 if (fixtureComponent.Fixtures.TryGetValue(key, out var fixture))
+                {
                     _physics.SetCollisionMask(uid, key, fixture, fixture.CollisionMask | StandingCollisionLayer, fixtureComponent);
+                }
+
+
             }
         }
         standingState.ChangedFixtures.Clear();
+        if (TryComp<ClimbingComponent>(uid, out var component))
+        {
+
+            foreach (var entity in _physics.GetEntitiesIntersectingBody(uid, StandingCollisionLayer, true))
+            {
+                if (TryComp<ClimbableComponent>(entity, out var climbable))
+                {
+                    _climbing.ForciblySetClimbing(uid, entity, component);
+                }
+            }
+        }
 
         return true;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR makes it so that when standing up, entities that can climb will be climbing. If somebody is knocked over and stands up onto a table, the game forces them off of the table, which often results in them being crammed into walls and suffocating if they aren't able to get out. It's possible that I look into prediction for this in the future.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfixes, required for my upcoming pushing PR to not break the game and make it extremely easy to kill people.
## Technical details
<!-- Summary of code changes for easier review. -->
In the 'stand' function of StandingStateSystem, there is a check at the end that will set the user to climbing if the ClimbingComponent is on the user and it is intersecting a climbable entity.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/61db8a2d-d0cf-4a91-aa19-72faf463374c


## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Standing up while on a table shouldn't make people suffocate in walls.
-->
