### PR TITLE
Light Attacks Respect Attack Range

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -208,13 +208,12 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         EntityUid? target = null;
         if (_stateManager.CurrentState is GameplayStateBase screen)
         {
-            // 'null' session on InRange makes me a little nervous. If anything odd happens with multiple clients, I might have to re-do that part.
             // Priority is: Clicked Entity -> Ray Collision -> Potential Target Around the Ray.
             var targetCast = TargetCast(attacker, coordinates, meleeComponent);
             coordinates = targetCast.Item1;
             var clicked = screen.GetClickedEntity(mousePos);
 
-            if (clicked == null || !InRange(attacker, clicked.Value, meleeComponent.Range, null))
+            if (clicked == null || (TransformSystem.GetWorldPosition(attacker) - TransformSystem.GetWorldPosition(clicked.Value)).Length() > meleeComponent.Range)
             {
                 var validEntity = _lookup.GetEntitiesInRange(coordinates, MeleeRange).FirstOrNull(j => j.Id != attacker.Id && TryComp<PhysicsComponent>(j, out var physics) && (physics.CollisionMask & AttackMask) != 0);
                 target = targetCast.Item2 ?? validEntity;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This PR makes it so that light attacks properly use the melee weapon's range to determine if a clicked entity should be hit, rather than interaction range.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixing a bug. You shouldn't be able to hit someone outside of the range of the weapon, regardless of how good your aim is.
## Technical details
<!-- Summary of code changes for easier review. -->
Replaced the InRange check in ClientLightAttack to use basically the same thing with a more manual check to determine if it is in attack range.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Melee Light Attacks now use the weapon's range properly.
